### PR TITLE
Hide legend description when building fill is supressed.

### DIFF
--- a/app/map_styles/polygon.xml
+++ b/app/map_styles/polygon.xml
@@ -1222,6 +1222,8 @@
             <LineSymbolizer stroke="#888" stroke-width="3.0"/>
         </Rule>
     </Style>
+    <Style name="empty_map">
+    </Style>
     <Style name="likes">
         <Rule>
             <Filter>[likes] &gt;= 100</Filter>

--- a/app/src/frontend/building/data-containers/age-history.tsx
+++ b/app/src/frontend/building/data-containers/age-history.tsx
@@ -81,6 +81,7 @@ const AgeHistoryView: React.FunctionComponent<CategoryViewProps> = (props) => {
         if (historicMapLeicestershire === 'enabled') {
             historicMapLeicestershireSwitchOnClick(e);
         }
+        props.onMapColourScale('empty_map');
     }
 
     const switchToStylePeriodMapStyle = (e) => {

--- a/app/src/frontend/config/category-maps-config.ts
+++ b/app/src/frontend/config/category-maps-config.ts
@@ -102,6 +102,15 @@ export const categoryMapsConfig: {[key in Category]: CategoryMapDefinition[]} = 
                 ]
             }
         },
+        {
+            mapStyle: 'empty_map',
+            legend: {
+                disclaimer: ' ',
+                title: '---',
+                elements: [
+                ]
+            }
+        },
     ],
     [Category.ConstructionDesign]: [
         {

--- a/app/src/frontend/config/tileserver-config.ts
+++ b/app/src/frontend/config/tileserver-config.ts
@@ -46,6 +46,7 @@ export type BuildingMapTileset =
     'team' |
     'team_known_designer' |
     'survival_status'|
+    'empty_map'|
     'typology_classification'|
     'typology_style_period' |
     'typology_dynamic_classification'|

--- a/app/src/tiles/dataDefinition.ts
+++ b/app/src/tiles/dataDefinition.ts
@@ -238,6 +238,13 @@ const LAYER_QUERIES = {
             buildings
         WHERE
         survival_status IS NOT NULL`,
+    empty_map: `
+        SELECT
+            geometry_id,
+            survival_status
+        FROM
+            buildings
+         WHERE FALSE`,
     survival_source: `
         SELECT
             geometry_id,


### PR DESCRIPTION
relatively painless way of achieving this effect

when historic map style without fill is enabled

![screen04](https://github.com/user-attachments/assets/0eaf5513-4151-448f-a310-f0a1c246e0af)

empty style is selectable

![screen05](https://github.com/user-attachments/assets/ff55665a-667d-40c6-895d-60b68474a0e7)
